### PR TITLE
Potential fix for divide-by-zero

### DIFF
--- a/Run/Delta/Ann/JerseyPoint_data.wresl
+++ b/Run/Delta/Ann/JerseyPoint_data.wresl
@@ -185,11 +185,11 @@ define JP_m_sv {
     condition  JP_b_sv >= 999990.
     value 0.}
    case negExpSensitivity{
-    condition JP_a2_sv < -0.0001 .and. month >=Oct .and. month <=Jan .or. month >=APR .and. month <=Sep
+    condition JP_a2_sv < -0.0001 .and. (month >=Oct .and. month <=Jan .or. month >=APR .and. month <=Sep)
 	Value JP_a1_sv/JP_a2_sv
 	}    
    case lowExpSensitivity{
-    condition JP_a2_sv < 0.0001 .and. month >=Oct .and. month <=Jan .or. month >=APR .and. month <=Sep
+    condition JP_a2_sv < 0.0001 .and. (month >=Oct .and. month <=Jan .or. month >=APR .and. month <=Sep)
 	Value 1.
 	}    
   case control{


### PR DESCRIPTION
I think the operator precedence was making the <0.0001 check only apply to months after Oct and before Jan. Meaning JP_a2_sv was allowed to be equal 0 if the month was between april and sept.

I think the old code was parsing like:
( JP_a2_sv < 0.0001  .and.  month >= Oct  .and.  month <= Jan )
  .or.
( month >= APR      .and.  month <= Sep )

Which isn't what I think was intended.
